### PR TITLE
🐛 Use Sdf.ChangeBlock only in some cases

### DIFF
--- a/cmake/modules/FindTBB.cmake
+++ b/cmake/modules/FindTBB.cmake
@@ -288,8 +288,8 @@ if(NOT TBB_FOUND)
             set_target_properties(tbb PROPERTIES IMPORTED_LOCATION ${TBB_LIBRARIES_RELEASE})
         else()
             set_target_properties(tbb PROPERTIES
-                                  INTERFACE_COMPILE_DEFINITIONS "${TBB_DEFINITIONS_DEBUG}"
-                                  IMPORTED_LOCATION              ${TBB_LIBRARIES_DEBUG}
+                                  INTERFACE_COMPILE_DEFINITIONS "${TBB_DEFINITIONS}"
+                                  IMPORTED_LOCATION              ${TBB_LIBRARIES}
                                   )
         endif()
     endif()

--- a/pxr/usdQtEditors/outliner.py
+++ b/pxr/usdQtEditors/outliner.py
@@ -441,7 +441,7 @@ class SelectVariants(MenuAction):
 
     @staticmethod
     def _ApplyVariantBatch(prims, variantSetName, variantValue, context):
-        def itterate_prims(prims):
+        def iterate_prims(prims):
             for prim in prims:
                 view = context.outliner.view
                 variantSet = prim.GetVariantSet(variantSetName)
@@ -471,11 +471,10 @@ class SelectVariants(MenuAction):
                 variantSetName == "anim_variant"
                 and variantValue != "cache"
             ):
-                for prim in prims:
-                    itterate_prims(prims)
+                iterate_prims(prims)
             else:
                 with Sdf.ChangeBlock():
-                    itterate_prims(prims)
+                    iterate_prims(prims)
 
     def Build(self, context):
         prims = context.selectedPrims


### PR DESCRIPTION
When changing department variant to animation on multiple characters
Sdf.ChangeBlock caused the rig to only be loaded for the first
character